### PR TITLE
Add RGBA32BitmapHeader

### DIFF
--- a/lib/src/blurhash.dart
+++ b/lib/src/blurhash.dart
@@ -54,7 +54,10 @@ Uint8List decodeBlurHash(
     );
   }
 
-  return _transform(width, height, numCompX, numCompY, colors);
+  Uint8List image = _transform(width, height, numCompX, numCompY, colors);
+  _RGBA32BitmapHeader header = _RGBA32BitmapHeader(image.length, width, height);
+
+  return header.appendContent(image);
 }
 
 /// Encodes an image to a BlurHash string
@@ -185,4 +188,43 @@ Color _multiplyBasisFunction(
 
   final scale = 1.0 / (width * height);
   return Color(r * scale, g * scale, b * scale);
+}
+
+const int _RGBA32HeaderSize = 122;
+
+class _RGBA32BitmapHeader {
+  final int contentSize;
+  Uint8List headerIntList;
+
+  /// Create a new RGBA32 header
+  _RGBA32BitmapHeader(this.contentSize, int width, int height) {
+    final int fileLength = contentSize + _RGBA32HeaderSize;
+    headerIntList = Uint8List(fileLength);
+    headerIntList.buffer.asByteData()
+      ..setUint8(0x0, 0x42)
+      ..setUint8(0x1, 0x4d)
+      ..setInt32(0x2, fileLength, Endian.little)
+      ..setInt32(0xa, _RGBA32HeaderSize, Endian.little)
+      ..setUint32(0xe, 108, Endian.little)
+      ..setUint32(0x12, width, Endian.little)
+      ..setUint32(0x16, -height, Endian.little)
+      ..setUint16(0x1a, 1, Endian.little)
+      ..setUint32(0x1c, 32, Endian.little)
+      ..setUint32(0x1e, 3, Endian.little)
+      ..setUint32(0x22, contentSize, Endian.little)
+      ..setUint32(0x36, 0x000000ff, Endian.little)
+      ..setUint32(0x3a, 0x0000ff00, Endian.little)
+      ..setUint32(0x3e, 0x00ff0000, Endian.little)
+      ..setUint32(0x42, 0xff000000, Endian.little);
+  }
+
+  Uint8List appendContent(Uint8List contentIntList) {
+    headerIntList.setRange(
+      _RGBA32HeaderSize,
+      contentSize + _RGBA32HeaderSize,
+      contentIntList,
+    );
+
+    return headerIntList;
+  }
 }


### PR DESCRIPTION
This PR adds a RGBA32 header to the decoded image. With this there's no need for the/a bitmap library anymore. In Flutter we can then directly use the result like

```Dart
String blurHash = "LEHV6nWB2yk8pyo0adR*.7kCMdnj";
Uint8List decodedImage = decodeBlurHash(blurHash, 305, 200);
Image.memory(decodedImage);
```