### PR TITLE
Make `decodeAC` consistent with the reference implementation

### DIFF
--- a/lib/src/foundation.dart
+++ b/lib/src/foundation.dart
@@ -48,8 +48,8 @@ ColorTriplet decodeDc(int value) {
 }
 
 ColorTriplet decodeAc(int value, double maxVal) {
-  final r = value / (19.0 * 19.0);
-  final g = (value / 19.0) % 19.0;
+  final r = (value / (19 * 19)).floor();
+  final g = (value / 19).floor() % 19;
   final b = value % 19.0;
 
   return ColorTriplet(


### PR DESCRIPTION
The official repo `floor` the float before calculating like this https://github.com/woltapp/blurhash/blob/f1edb10ba0e0b78c95698488c7665fcb75d69aa2/TypeScript/src/decode.ts#L49-L51